### PR TITLE
add `extra` to the logger.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,3 +5,4 @@ Authors & contributors
 * Jonathan Dorival <jonathan.dorival@novapost.fr>
 * Rémy Hubscher <remy.hubscher@novapost.fr>
 * Ionel Cristian Mărieș <contact@ionelmc.ro>
+* Keryn Knight <keryn@kerynknight.com>

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,7 @@ Changelog
 0.3 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Request info is provided to the logger.
 
 
 0.2 (2013-11-26)

--- a/django_js_error_hook/views.py
+++ b/django_js_error_hook/views.py
@@ -17,7 +17,10 @@ class JSErrorHandlerView(View):
         """Read POST data and log it as an JS error"""
         error_dict = request.POST.dict()
         error_dict['user'] = request.user if request.user.is_authenticated() else "<UNAUTHENTICATED>"
-        logger.error("Got error: \n%s", '\n'.join("\t%s: %s" % (key, value) for key, value in error_dict.items()))
+        logger.error("Got error: \n%s", '\n'.join("\t%s: %s" % (key, value) for key, value in error_dict.items()), extra={
+                        'status_code': 500,
+                        'request': request
+                    })
         return HttpResponse('Error logged')
 
 class MimetypeTemplateView(TemplateView):


### PR DESCRIPTION
Allow for logging handlers to inspect the `request` and `status_code`, as Django does internally in places.

This allows for configuring LOGGING to do things like:

```
LOGGING = {
    ...
    'loggers': {
        ...
        'javascript_error': {
            'handlers': ['mail_admins', 'console'],
            'level': 'ERROR',
            'propagate': True,
        },
    }
}
```

the important part being `mail_admins`, which is configured as a handler that uses the `django.utils.log.AdminEmailHandler` class, though any handler class could theoretically make use of the `extra` values.

Thus, the endpoint for the error email (in our case, a ticketing system) now includes the WSGIRequest repr.
Pros:
- all kinds of extra data, looks like the rest of the exceptions.
  - cookies
  - info about which server received this request
  - user agent (thus could be removed from the `logging.error` in the view)

Cons:
- the WSGIRequest `path` attribute will reflect the JS-onerror endpoint, rather than the originating URL (which instead exists in the referrer, if given)
