### PR TITLE
Middleware for hooking into every request and option to capture calls to window.console.log.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,10 @@ If you want to log the error in the console for development::
 By default the logger is called "javascript_error", if you want you can define ``JAVASCRIPT_ERROR_ID`` in your settings::
 
    JAVASCRIPT_ERROR_ID = '<your logger name>'
+   
+Enable logging of every ``window.console.log`` call by setting ``JAVASCRIPT_ERROR_PROXY_CONSOLE`` in your settings::
+
+   JAVASCRIPT_ERROR_PROXY_CONSOLE = True
 
 The view will do csrf validation - if for some reason it doesn't work, set ``JAVASCRIPT_ERROR_CSRF_EXEMPT`` to ``True`` in your settings.
 
@@ -92,6 +96,15 @@ Then install the urls::
 In your template, simply add the js_error_hook script::
 
     <script type="text/javascript" src="{% url js-error-handler-js %}"></script>
+    
+Or add ``django_js_error_hook.middleware.JSErrorHookMiddleware`` to your ``settings.MIDDLEWARE_CLASSES`` 
+to hook into every request::
+
+    MIDDLEWARE_CLASSES = (
+	    ...
+	'django_js_error_hook.middleware.JSErrorHookMiddleware',
+	...
+    )
 
 Now every Javascript error will be logged in your logging error stream. (Mail, Sentry, ...)
 

--- a/django_js_error_hook/middleware.py
+++ b/django_js_error_hook/middleware.py
@@ -1,0 +1,52 @@
+'''
+Javascript Error Hook Middleware
+
+Inspired by Debug Toolbar middleware see:
+https://github.com/django-debug-toolbar/django-debug-toolbar/blob/master/debug_toolbar/middleware.py
+'''
+
+from __future__ import absolute_import, unicode_literals
+
+from django.utils.encoding import force_text
+from django.conf import settings
+from django.core.urlresolvers import reverse_lazy as reverse
+
+import re
+
+
+_HTML_TYPES = ('text/html', 'application/xhtml+xml')
+_SCRIPT_TAG = '<script type="text/javascript" src="%s"></script>'
+
+
+INSERT_BEFORE = getattr(
+    settings,
+    'JAVASCRIPT_ERROR_INSERT_BEFORE',
+    '</body>'
+)
+
+
+class JSErrorHookMiddleware(object):
+    def process_response(self, request, response):
+        # Check for responses where the js-logger can't be inserted.
+        content_encoding = response.get('Content-Encoding', '')
+        content_type = response.get(
+            'Content-Type', '').split(';')[0]
+        
+        if any((getattr(response, 'streaming', False),
+                'gzip' in content_encoding,
+                content_type not in _HTML_TYPES)):
+            return response
+
+        # Insert the js-logger in the response.
+        content = force_text(
+            response.content, encoding=settings.DEFAULT_CHARSET)
+
+        pattern = re.escape(INSERT_BEFORE)
+        bits = re.split(pattern, content, flags=re.IGNORECASE)
+
+        if len(bits) > 1:
+            bits[-2] += _SCRIPT_TAG % reverse('js-error-handler-js')
+            response.content = INSERT_BEFORE.join(bits)
+            if response.get('Content-Length', None):
+                response['Content-Length'] = len(response.content)
+        return response

--- a/django_js_error_hook/templates/django_js_error_hook/utils.js
+++ b/django_js_error_hook/templates/django_js_error_hook/utils.js
@@ -40,4 +40,14 @@
 	window.onerror = function(error_msg, url, line_number) {
 		logError(url + ':' + line_number + ': ' + error_msg);
 	};
+
+    {% if proxy_console %}
+    
+        var proxied_log = window.console.log;
+        window.console.log = function(){
+	    logError(Array.prototype.slice.call(
+		arguments).join(','));
+	    return proxied_log.apply(this, arguments);
+        };
+    {% endif %}
 })();

--- a/django_js_error_hook/templates/django_js_error_hook/utils.js
+++ b/django_js_error_hook/templates/django_js_error_hook/utils.js
@@ -68,13 +68,15 @@ var djErrorHook = (function(djErrorHook, undefined){
 
     {% if proxy_console %}
     
-    var proxied_log = window.console.log;
+    var proxied_log = window.console && window.console.log;
 
     window.console.log = function(){
 	djErrorHook.logError(
 	    'CONSOLE: ' + Array.prototype.slice.call(
 		arguments).join(','));
-	return proxied_log.apply(this, arguments);
+	if(proxied_log && proxied_log.apply){
+	    proxied_log.apply(this, arguments);
+	}
     };
 
     {% endif %}

--- a/django_js_error_hook/templates/django_js_error_hook/utils.js
+++ b/django_js_error_hook/templates/django_js_error_hook/utils.js
@@ -1,80 +1,86 @@
 {% load url from future %}
-(function(){
+(function(djErrorHook, undefined){
+    
+    window.djErrorHook = djErrorHook;
 
-	function getCookie(name){
-	    var nameEQ = name + "=";
-	    var c, ca = document.cookie.split(';');
-	    
-	    for(var i = 0; i < ca.length; i++){
-		c = ca[i];
-		while(c.charAt(0) == ' ') 
-		    c = c.substring(1, c.length);
-		if(c.indexOf(nameEQ) == 0) 
-		    return c.substring(
-			nameEQ.length, c.length);
-	    }
-	    return null;
+    function getCookie(name){
+	var nameEQ = name + "=";
+	var c, ca = document.cookie.split(';');
+	
+	for(var i = 0; i < ca.length; i++){
+	    c = ca[i];
+	    while(c.charAt(0) == ' ') 
+		c = c.substring(1, c.length);
+	    if(c.indexOf(nameEQ) == 0) 
+		return c.substring(
+		    nameEQ.length, c.length);
 	}
+	return null;
+    }
 
-	function logError(details){
-	    var cookie = getCookie('csrftoken'),
-    	        query = [],
-	        data = {
-		    context: navigator.userAgent,
-		    details: details
-		},
-                xhr;
+    djErrorHook.logError = function(details){
+	var cookie = getCookie('csrftoken'),
+    	query = [],
+	data = {
+	    context: navigator.userAgent,
+	    details: details
+	},
+        xhr;
 
+	try{
+	    xhr = new ActiveXObject('Msxml2.XMLHTTP');
+	}
+	catch(e1){
 	    try{
-		xhr = new ActiveXObject('Msxml2.XMLHTTP');
+		xhr = new ActiveXObject('Microsoft.XMLHTTP');
+	    }catch(e2){
+		xhr = new XMLHttpRequest();
 	    }
-	    catch(e1){
-		try{
-		    xhr = new ActiveXObject('Microsoft.XMLHTTP');
-		}catch(e2){
-		    xhr = new XMLHttpRequest();
-		}
-	    }
-
-	    xhr.open(
-		"POST", 
-		"{% url 'js-error-handler' %}", 
-		false
-	    );
-
-	    xhr.setRequestHeader(
-		'Content-type', 
-		'application/x-www-form-urlencoded'
-	    );
-
-	    if(cookie){
-		xhr.setRequestHeader("X-CSRFToken", cookie);
-	    }
-
-	    for(var key in data){
-		query.push(
-		    encodeURIComponent(key) + 
-			'=' + 
-			encodeURIComponent(data[key])
-		);
-	    }
-	    xhr.send(query.join('&'));
 	}
 
-	window.onerror = function(error_msg, url, line_number){
-	    logError(url + ':' + line_number + ': ' + error_msg);
-	};
+	xhr.open(
+	    "POST", 
+	    "{% url 'js-error-handler' %}", 
+	    false
+	);
+
+	xhr.setRequestHeader(
+	    'Content-type', 
+	    'application/x-www-form-urlencoded'
+	);
+
+	if(cookie){
+	    xhr.setRequestHeader("X-CSRFToken", cookie);
+	}
+
+	for(var key in data){
+	    query.push(
+		encodeURIComponent(key) + 
+		    '=' + 
+		    encodeURIComponent(data[key])
+	    );
+	}
+	xhr.send(query.join('&'));
+    };
+
+    window.onerror = function(error_msg, url, line_number){
+	djErrorHook.logError(
+	    url + ':' + line_number + ': ' + error_msg);
+    };
 
     {% if proxy_console %}
     
-        var proxied_log = window.console.log;
+    var proxied_log = window.console.log;
 
-        window.console.log = function(){
-	    logError(Array.prototype.slice.call(
+    window.console.log = function(){
+	djErrorHook.logError(
+	    'CONSOLE: ' + Array.prototype.slice.call(
 		arguments).join(','));
-	    return proxied_log.apply(this, arguments);
-        };
+	return proxied_log.apply(this, arguments);
+    };
 
     {% endif %}
     
-})();
+})(
+    window.djErrorHook || {}
+);

--- a/django_js_error_hook/templates/django_js_error_hook/utils.js
+++ b/django_js_error_hook/templates/django_js_error_hook/utils.js
@@ -1,8 +1,6 @@
 {% load url from future %}
-(function(djErrorHook, undefined){
+var djErrorHook = (function(djErrorHook, undefined){
     
-    window.djErrorHook = djErrorHook;
-
     function getCookie(name){
 	var nameEQ = name + "=";
 	var c, ca = document.cookie.split(';');
@@ -80,7 +78,9 @@
     };
 
     {% endif %}
+
+    return djErrorHook;
     
 })(
-    window.djErrorHook || {}
+    djErrorHook || {}
 );

--- a/django_js_error_hook/templates/django_js_error_hook/utils.js
+++ b/django_js_error_hook/templates/django_js_error_hook/utils.js
@@ -1,53 +1,80 @@
 {% load url from future %}
-(function() {
-	function getCookie(name) {
-		var nameEQ = name + "=";
-		var ca = document.cookie.split(';');
-		for(var i=0;i < ca.length;i++) {
-			var c = ca[i];
-			while (c.charAt(0)==' ') c = c.substring(1,c.length);
-			if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length,c.length);
-		}
-		return null;
-	}
-	function logError(details) {
-		var xhr;
-		try {
-			xhr = new ActiveXObject('Msxml2.XMLHTTP');
-		} catch (e1) {
-			try {
-				xhr = new ActiveXObject('Microsoft.XMLHTTP');
-			} catch (e2) {
-				xhr = new XMLHttpRequest();
-			}
-		}
-		xhr.open("POST", "{% url 'js-error-handler' %}", false);
-		xhr.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
-		var cookie = getCookie('csrftoken');
-		if (cookie) {
-			xhr.setRequestHeader("X-CSRFToken", cookie);
-		}
-		var query = [], data = {
-			context: navigator.userAgent,
-			details: details
-		};
-		for (var key in data) {
-			query.push(encodeURIComponent(key) + '=' + encodeURIComponent(data[key]));
-		}
-		xhr.send(query.join('&'));
+(function(){
+
+	function getCookie(name){
+	    var nameEQ = name + "=";
+	    var c, ca = document.cookie.split(';');
+	    
+	    for(var i = 0; i < ca.length; i++){
+		c = ca[i];
+		while(c.charAt(0) == ' ') 
+		    c = c.substring(1, c.length);
+		if(c.indexOf(nameEQ) == 0) 
+		    return c.substring(
+			nameEQ.length, c.length);
+	    }
+	    return null;
 	}
 
-	window.onerror = function(error_msg, url, line_number) {
-		logError(url + ':' + line_number + ': ' + error_msg);
+	function logError(details){
+	    var cookie = getCookie('csrftoken'),
+    	        query = [],
+	        data = {
+		    context: navigator.userAgent,
+		    details: details
+		},
+                xhr;
+
+	    try{
+		xhr = new ActiveXObject('Msxml2.XMLHTTP');
+	    }
+	    catch(e1){
+		try{
+		    xhr = new ActiveXObject('Microsoft.XMLHTTP');
+		}catch(e2){
+		    xhr = new XMLHttpRequest();
+		}
+	    }
+
+	    xhr.open(
+		"POST", 
+		"{% url 'js-error-handler' %}", 
+		false
+	    );
+
+	    xhr.setRequestHeader(
+		'Content-type', 
+		'application/x-www-form-urlencoded'
+	    );
+
+	    if(cookie){
+		xhr.setRequestHeader("X-CSRFToken", cookie);
+	    }
+
+	    for(var key in data){
+		query.push(
+		    encodeURIComponent(key) + 
+			'=' + 
+			encodeURIComponent(data[key])
+		);
+	    }
+	    xhr.send(query.join('&'));
+	}
+
+	window.onerror = function(error_msg, url, line_number){
+	    logError(url + ':' + line_number + ': ' + error_msg);
 	};
 
     {% if proxy_console %}
     
         var proxied_log = window.console.log;
+
         window.console.log = function(){
 	    logError(Array.prototype.slice.call(
 		arguments).join(','));
 	    return proxied_log.apply(this, arguments);
         };
+
     {% endif %}
+    
 })();

--- a/django_js_error_hook/views.py
+++ b/django_js_error_hook/views.py
@@ -7,6 +7,8 @@ import logging
 
 ERROR_ID = getattr(settings, 'JAVASCRIPT_ERROR_ID', 'javascript_error')
 CSRF_EXEMPT = getattr(settings, 'JAVASCRIPT_ERROR_CSRF_EXEMPT', False)
+PROXY_CONSOLE = getattr(
+    settings, 'JAVASCRIPT_ERROR_PROXY_CONSOLE', False)
 
 logger = logging.getLogger(ERROR_ID)
 
@@ -31,6 +33,7 @@ class MimetypeTemplateView(TemplateView):
     def render_to_response(self, context, **response_kwargs):
         """Use self.mimetype to return the right mimetype"""
         response_kwargs['mimetype'] = self.mimetype
+        context['proxy_console'] = PROXY_CONSOLE
         return super(MimetypeTemplateView, self).render_to_response(context, **response_kwargs)
 
 utils_js = cache_page(2 * 31 * 24 * 60 * 60)(MimetypeTemplateView.as_view()) #: Cache 2 months


### PR DESCRIPTION
Instead of adding the `<script src=".."></script>` tag include the middleware to hook into every request.

Optionally capture every call to `window.console.log` (This is quite browser intensive)
