### PR TITLE
better handling of unhandledrejections with non Error reasons

### DIFF
--- a/demo/demoproject/templates/error_test.html
+++ b/demo/demoproject/templates/error_test.html
@@ -10,13 +10,22 @@
     </head>
 
     <body>
-       A simple Page which voluntary triggers a regular JavaScript error and an unhandled promise rejection error (Ctrl+U to see the script causing the errors). 
+       A simple Page which voluntary triggers a regular JavaScript error and an unhandled promise rejection error (Ctrl+U to see the script causing the errors).
         <script type="text/javascript">
             a fu***ng javascript error
         </script>
         <script type="text/javascript">
             new Promise(function(resolve, reject) {
                 window.fish.mountain = 'some text';
+            })
+            new Promise(function(resolve, reject) {
+                reject(new Error('my reason')); // Reason is an error -- it is logged WITH stack.
+            })
+            new Promise(function(resolve, reject) {
+                reject('bad reason'); // Reason is other object -- reason is logged as message is logged WITHOUT stack.
+            })
+            new Promise(function(resolve, reject) {
+                reject(); // No reason given means rejection is logged WITHOUT stack and WITHOUT message;
             })
         </script>
     </body>

--- a/django_js_error_hook/templates/django_js_error_hook/utils.js
+++ b/django_js_error_hook/templates/django_js_error_hook/utils.js
@@ -39,14 +39,20 @@
 		logError(log_message);
 	};
 
-	window.onunhandledrejection = function(rejection) {
-		var log_message = rejection.type;
-		if (rejection.reason && rejection.reason.message) {
-			log_message += ", " + rejection.reason.message;
-		}
-		if (rejection.reason && rejection.reason.stack) {
-			log_message += ", " + rejection.reason.stack;
-		}
-		logError(log_message);
-	};
+	if (window.addEventListener) {
+		window.addEventListener('unhandledrejection', function(rejection) {
+			var log_message = rejection.type;
+			if (rejection.reason) {
+				if (rejection.reason.message) {
+					log_message += ", " + rejection.reason.message;
+				} else {
+					log_message += ", " + JSON.stringify(rejection.reason);
+				}
+				if (rejection.reason.stack) {
+					log_message += ", " + rejection.reason.stack;
+				}
+			}
+			logError(log_message);
+		})
+	}
 })();


### PR DESCRIPTION
there is currently nothing restricting the format of promise rejection reasons, but unless the reason is an error, we don't log it. This adds such logging.

I can see in the browser developer console that the browser is also keeping stack information for such rejected promises. But it seems not to be available within JavaScript, so we can only log these without a stack trace.