### PR TITLE
Allow blacklisting of custom useragents or errors

### DIFF
--- a/django_js_error_hook/views.py
+++ b/django_js_error_hook/views.py
@@ -10,6 +10,8 @@ import logging
 
 ERROR_ID = getattr(settings, 'JAVASCRIPT_ERROR_ID', 'javascript_error')
 CSRF_EXEMPT = getattr(settings, 'JAVASCRIPT_ERROR_CSRF_EXEMPT', False)
+BLACKLIST_USERAGENT = getattr(settings, 'JAVASCRIPT_ERROR_USERAGENT_BLACKLIST', ['googlebot', 'bingbot'])
+BLACKLIST_ERRORS = getattr(settings, 'JAVASCRIPT_ERROR_BLACKLIST', [])
 
 logger = logging.getLogger(ERROR_ID)
 
@@ -21,7 +23,11 @@ class JSErrorHandlerView(View):
         """Read POST data and log it as an JS error"""
         error_dict = request.POST.dict()
         error_dict['user'] = request.user if request.user.is_authenticated else "<UNAUTHENTICATED>"
-        logger.error("Got error: \n%s", '\n'.join("\t%s: %s" % (key, value) for key, value in error_dict.items()), extra={
+        level = logging.ERROR
+        if any(useragent in error_dict['context'].lower() for useragent in BLACKLIST_USERAGENT) or \
+                any(error in error_dict['details'].lower() for error in BLACKLIST_ERRORS):
+            level = logging.WARNING
+        logger.log(level, "Got error: \n%s", '\n'.join("\t%s: %s" % (key, value) for key, value in error_dict.items()), extra={
                         'status_code': 500,
                         'request': request
                     })


### PR DESCRIPTION
Some simple string matching on errors and user agents to reduce loglevel. Used for disable logging for bots with poor javascript support and other old browsers.