### PR TITLE
Handle no user in request

### DIFF
--- a/django_js_error_hook/views.py
+++ b/django_js_error_hook/views.py
@@ -20,7 +20,12 @@ class JSErrorHandlerView(View):
     def post(self, request):
         """Read POST data and log it as an JS error"""
         error_dict = request.POST.dict()
-        error_dict['user'] = request.user if request.user.is_authenticated else "<UNAUTHENTICATED>"
+        if hasattr(request, 'user'):
+            error_dict['user'] = request.user if request.user.is_authenticated else "<UNAUTHENTICATED>"
+        else:
+            error_dict['user'] = "<UNAUTHENTICATED>"
+
+            
         logger.error("Got error: \n%s", '\n'.join("\t%s: %s" % (key, value) for key, value in error_dict.items()), extra={
                         'status_code': 500,
                         'request': request


### PR DESCRIPTION
In some cases there may not be a user in the request, so handle without raising an error which masks the error being reported.