### PR TITLE
respect logging level

### DIFF
--- a/django_js_error_hook/views.py
+++ b/django_js_error_hook/views.py
@@ -32,10 +32,14 @@ class JSErrorHandlerView(View):
                 any(error in error_dict['details'].lower() for error in BLACKLIST_ERRORS):
             level = logging.WARNING
 
-        logger.error("Got error: \n%s", '\n'.join("\t%s: %s" % (key, value) for key, value in error_dict.items()), extra={
-                        'status_code': 500,
-                        'request': request
-                    })
+        logger.log(
+            level,
+            "Got error: \n%s", '\n'.join("\t%s: %s" % (key, value) for key, value in error_dict.items()), 
+            extra={
+                'status_code': 500,
+                'request': request
+            }
+        )
         return HttpResponse('Error logged')
 
 


### PR DESCRIPTION
The option to set the logging level to WARNING that was introduced in https://github.com/jojax/django-js-error-hook/commit/559a4c77212cada444ab548c153a45888fb6a88d#diff-9b77876fe451deb3281fc571c27f2eefR30 was lost again in a subsequent commit. This reestablishes it.

Hey @Natim - could we make a new release with this? The 0.7 release is slightly broken due to this feature being only half there.